### PR TITLE
imdsclient: better retries with tokio retry and timeout

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "tokio-retry",
  "tokio-test",
  "url",
 ]
@@ -3440,6 +3441,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project 1.0.8",
+ "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/sources/api/early-boot-config/src/provider/aws.rs
+++ b/sources/api/early-boot-config/src/provider/aws.rs
@@ -85,7 +85,7 @@ impl PlatformDataProvider for AwsDataProvider {
     ) -> std::result::Result<Vec<SettingsJson>, Box<dyn std::error::Error>> {
         let mut output = Vec::new();
 
-        let mut client = ImdsClient::new().await.context(error::ImdsClient)?;
+        let mut client = ImdsClient::new().context(error::ImdsClient)?;
 
         // Attempt to read from local file first on the `aws-dev` variant
         #[cfg(bottlerocket_platform = "aws-dev")]

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -303,7 +303,7 @@ fn parse_args(mut args: env::Args) -> String {
 
 async fn run() -> Result<()> {
     let setting_name = parse_args(env::args());
-    let mut client = ImdsClient::new().await.context(error::ImdsClient)?;
+    let mut client = ImdsClient::new().context(error::ImdsClient)?;
 
     let setting = match setting_name.as_ref() {
         "cluster-dns-ip" => get_cluster_dns_ip(&mut client).await,

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -42,7 +42,7 @@ impl UserData {
 /// Returns a list of public keys.
 async fn fetch_public_keys_from_imds() -> Result<Vec<String>> {
     info!("Connecting to IMDS");
-    let mut client = ImdsClient::new().await.context(error::ImdsClient)?;
+    let mut client = ImdsClient::new().context(error::ImdsClient)?;
     let public_keys = client
         .fetch_public_ssh_keys()
         .await

--- a/sources/imdsclient/Cargo.toml
+++ b/sources/imdsclient/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { version = "0.11.1", default-features = false }
 serde_json = "1"
 snafu = "0.6"
 tokio = { version = "~1.8", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
+tokio-retry = "0.3"
 url = "2.1.1"
 
 [build-dependencies]

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -16,13 +16,15 @@ The result is returned as a `String` _(ex. m5.large)_.
 
 #![deny(rust_2018_idioms)]
 
+use std::sync::RwLock;
+
 use http::StatusCode;
 use log::{debug, info, trace, warn};
 use reqwest::Client;
 use serde_json::Value;
 use snafu::{ensure, OptionExt, ResultExt};
-use std::time::Duration;
-use tokio::time;
+use tokio::time::{timeout, Duration};
+use tokio_retry::{strategy::FibonacciBackoff, Retry};
 
 const BASE_URI: &str = "http://169.254.169.254";
 const PINNED_SCHEMA: &str = "2021-01-03";
@@ -30,12 +32,18 @@ const PINNED_SCHEMA: &str = "2021-01-03";
 // Currently only able to get fetch session tokens from `latest`
 const SESSION_TARGET: &str = "latest/api/token";
 
+fn retry_strategy() -> impl Iterator<Item = Duration> {
+    // Retries (relative to start) at 0.5s, 1s, 2s, 3.5s, 6s, 10s, 16.5s, and then every 10s after.
+    FibonacciBackoff::from_millis(500).max_delay(Duration::from_secs(10))
+}
+
 /// A client for making IMDSv2 queries.
 /// It obtains a session token when it is first instantiated and is reused between helper functions.
 pub struct ImdsClient {
     client: Client,
     imds_base_uri: String,
-    session_token: String,
+    retry_timeout: Duration,
+    session_token: RwLock<String>,
 }
 
 impl ImdsClient {
@@ -45,12 +53,22 @@ impl ImdsClient {
 
     async fn new_impl(imds_base_uri: String) -> Result<Self> {
         let client = Client::new();
-        let session_token = fetch_token(&client, &imds_base_uri).await?;
+        // Retry token timeout tied to wicked.service ifup timeout
+        let retry_timeout = Duration::from_secs(300);
+        let session_token =
+            RwLock::new(fetch_token(&client, &imds_base_uri, &retry_timeout).await?);
         Ok(Self {
             client,
             imds_base_uri,
+            retry_timeout,
             session_token,
         })
+    }
+
+    /// Overrides the default timeout when building your own ImdsClient.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.retry_timeout = timeout;
+        self
     }
 
     /// Gets `user-data` from IMDS. The user-data may be either a UTF-8 string or compressed bytes.
@@ -221,91 +239,93 @@ impl ImdsClient {
             target.as_ref()
         );
         debug!("Requesting {}", &uri);
-        let mut attempt: u8 = 0;
-        let max_attempts: u8 = 3;
-        loop {
-            attempt += 1;
-            ensure!(attempt <= max_attempts, error::FailedFetchIMDS { attempt });
-            if attempt > 1 {
-                time::sleep(Duration::from_secs(1)).await;
-            }
-            let response = self
-                .client
-                .get(&uri)
-                .header("X-aws-ec2-metadata-token", &self.session_token)
-                .send()
-                .await
-                .context(error::Request {
-                    method: "GET",
-                    uri: &uri,
-                })?;
-            trace!("IMDS response: {:?}", &response);
-
-            match response.status() {
-                code @ StatusCode::OK => {
-                    info!("Received {}", target.as_ref());
-                    let response_body = response
-                        .bytes()
-                        .await
-                        .context(error::ResponseBody {
-                            method: "GET",
-                            uri: &uri,
-                            code,
-                        })?
-                        .to_vec();
-
-                    let response_str = printable_string(&response_body);
-                    trace!("Response: {:?}", response_str);
-
-                    return Ok(Some(response_body));
-                }
-
-                // IMDS returns 404 if no user data is given, or if IMDS is disabled
-                StatusCode::NOT_FOUND => return Ok(None),
-
-                // IMDS returns 401 if the session token is expired or invalid
-                StatusCode::UNAUTHORIZED => {
-                    info!("Session token is invalid or expired");
-                    self.refresh_token().await?;
-                    info!("Refreshed session token");
-                    continue;
-                }
-
-                StatusCode::REQUEST_TIMEOUT => {
-                    info!("Retrying request");
-                    continue;
-                }
-
-                code => {
-                    let response_body = response
-                        .bytes()
-                        .await
-                        .context(error::ResponseBody {
-                            method: "GET",
-                            uri: &uri,
-                            code,
-                        })?
-                        .to_vec();
-
-                    let response_str = printable_string(&response_body);
-
-                    trace!("Response: {:?}", response_str);
-
-                    return error::Response {
+        timeout(
+            self.retry_timeout,
+            Retry::spawn(retry_strategy(), || async {
+                let session_token = {
+                    self.session_token
+                        .read()
+                        .map_err(|_| error::Error::FailedReadToken {})?
+                        .clone()
+                };
+                let response = self
+                    .client
+                    .get(&uri)
+                    .header("X-aws-ec2-metadata-token", session_token)
+                    .send()
+                    .await
+                    .context(error::Request {
                         method: "GET",
                         uri: &uri,
-                        code,
-                        response_body: response_str,
+                    })?;
+                trace!("IMDS response: {:?}", &response);
+
+                match response.status() {
+                    code @ StatusCode::OK => {
+                        info!("Received {}", target.as_ref());
+                        let response_body = response
+                            .bytes()
+                            .await
+                            .context(error::ResponseBody {
+                                method: "GET",
+                                uri: &uri,
+                                code,
+                            })?
+                            .to_vec();
+
+                        let response_str = printable_string(&response_body);
+                        trace!("Response: {:?}", response_str);
+
+                        Ok(Some(response_body))
                     }
-                    .fail();
+
+                    // IMDS returns 404 if no user data is given, or if IMDS is disabled
+                    StatusCode::NOT_FOUND => Ok(None),
+
+                    // IMDS returns 401 if the session token is expired or invalid
+                    StatusCode::UNAUTHORIZED => {
+                        warn!("Session token is invalid or expired");
+                        self.refresh_token().await?;
+                        error::UnauthorizedTokenRefreshed.fail()
+                    }
+
+                    code => {
+                        let response_body = response
+                            .bytes()
+                            .await
+                            .context(error::ResponseBody {
+                                method: "GET",
+                                uri: &uri,
+                                code,
+                            })?
+                            .to_vec();
+
+                        let response_str = printable_string(&response_body);
+
+                        trace!("Response: {:?}", response_str);
+
+                        error::Response {
+                            method: "GET".to_string(),
+                            uri: uri.to_string(),
+                            code,
+                            response_body: response_str,
+                        }
+                        .fail()
+                    }
                 }
-            }
-        }
+            }),
+        )
+        .await
+        .context(error::TimeoutFetchIMDS)?
     }
 
     /// Fetches a new session token and adds it to the current ImdsClient.
-    async fn refresh_token(&mut self) -> Result<()> {
-        self.session_token = fetch_token(&self.client, &self.imds_base_uri).await?;
+    async fn refresh_token(&self) -> Result<()> {
+        *self
+            .session_token
+            .write()
+            .map_err(|_| error::Error::FailedWriteToken {})? =
+            fetch_token(&self.client, &self.imds_base_uri, &self.retry_timeout).await?;
         Ok(())
     }
 }
@@ -349,38 +369,36 @@ fn build_public_key_targets(public_key_list: &str) -> Vec<String> {
 }
 
 /// Helper to fetch an IMDSv2 session token that is valid for 60 seconds.
-async fn fetch_token(client: &Client, imds_base_uri: &str) -> Result<String> {
+async fn fetch_token(
+    client: &Client,
+    imds_base_uri: &str,
+    retry_timeout: &Duration,
+) -> Result<String> {
     let uri = format!("{}/{}", imds_base_uri, SESSION_TARGET);
-    let mut attempt: u8 = 0;
-    let max_attempts: u8 = 3;
-    loop {
-        attempt += 1;
-        ensure!(attempt <= max_attempts, error::FailedFetchToken { attempt });
-        if attempt > 1 {
-            time::sleep(Duration::from_secs(5)).await;
-        }
-        let response = client
-            .put(&uri)
-            .header("X-aws-ec2-metadata-token-ttl-seconds", "60")
-            .send()
-            .await
-            .context(error::Request {
-                method: "PUT",
-                uri: &uri,
-            })?;
+    timeout(
+        *retry_timeout,
+        Retry::spawn(retry_strategy(), || async {
+            let response = client
+                .put(&uri)
+                .header("X-aws-ec2-metadata-token-ttl-seconds", "60")
+                .send()
+                .await
+                .context(error::Request {
+                    method: "PUT",
+                    uri: &uri,
+                })?;
 
-        let code = response.status();
-        if code == StatusCode::OK {
+            let code = response.status();
+            ensure!(code == StatusCode::OK, error::FailedFetchToken);
             return response.text().await.context(error::ResponseBody {
                 method: "PUT",
                 uri: &uri,
                 code,
             });
-        } else {
-            info!("Retrying token request");
-            continue;
-        }
-    }
+        }),
+    )
+    .await
+    .context(error::TimeoutFetchToken)?
 }
 
 mod error {
@@ -401,17 +419,24 @@ mod error {
     #[snafu(visibility = "pub(super)")]
 
     pub enum Error {
+        // snafu doesn't yet support the lifetimes used by std::sync::PoisonError
         #[snafu(display("Response '{}' from '{}': {}", get_status_code(source), uri, source))]
         BadResponse { uri: String, source: reqwest::Error },
 
         #[snafu(display("IMDS fetch failed after {} attempts", attempt))]
         FailedFetchIMDS { attempt: u8 },
 
-        #[snafu(display("Failed to fetch IMDSv2 session token after {} attempts", attempt))]
-        FailedFetchToken { attempt: u8 },
+        #[snafu(display("Failed to fetch IMDSv2 session token"))]
+        FailedFetchToken,
+
+        #[snafu(display("Failed to read token within ImdsClient"))]
+        FailedReadToken,
 
         #[snafu(display("IMDS session failed: {}", source))]
         FailedSession { source: reqwest::Error },
+
+        #[snafu(display("Failed to write token to ImdsClient"))]
+        FailedWriteToken,
 
         #[snafu(display("Error retrieving key from {}", target))]
         KeyNotFound { target: String },
@@ -421,6 +446,9 @@ mod error {
 
         #[snafu(display("Response was not UTF-8: {}", source))]
         NonUtf8Response { source: std::string::FromUtf8Error },
+
+        #[snafu(display("IMDSv2 session token was refreshed."))]
+        UnauthorizedTokenRefreshed,
 
         #[snafu(display("Error {}ing '{}': {}", method, uri, source))]
         Request {
@@ -453,6 +481,12 @@ mod error {
 
         #[snafu(display("Deserialization error: {}", source))]
         Serde { source: serde_json::Error },
+
+        #[snafu(display("Timed out fetching data from IMDS: {}", source))]
+        TimeoutFetchIMDS { source: tokio::time::error::Elapsed },
+
+        #[snafu(display("Timed out fetching IMDSv2 session token: {}", source))]
+        TimeoutFetchToken { source: tokio::time::error::Elapsed },
     }
 }
 
@@ -479,7 +513,8 @@ mod test {
                 ),
         );
         let imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
-        assert_eq!(imds_client.session_token, token);
+        let imds_token = { imds_client.session_token.read().unwrap().clone() };
+        assert_eq!(imds_token, token);
     }
 
     #[tokio::test]
@@ -563,9 +598,10 @@ mod test {
         let schema_version = "latest";
         let target = "meta-data/instance-type";
         let response_code = 401;
+        let retry_timeout = Duration::from_secs(2);
         server.expect(
             Expectation::matching(request::method_path("PUT", "/latest/api/token"))
-                .times(4)
+                .times(2..)
                 .respond_with(
                     status_code(200)
                         .append_header("X-aws-ec2-metadata-token-ttl-seconds", "60")
@@ -577,12 +613,15 @@ mod test {
                 "GET",
                 format!("/{}/{}", schema_version, target),
             ))
-            .times(3)
+            .times(2..)
             .respond_with(
                 status_code(response_code).append_header("X-aws-ec2-metadata-token", token),
             ),
         );
-        let mut imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
+        let mut imds_client = ImdsClient::new_impl(base_uri)
+            .await
+            .unwrap()
+            .with_timeout(retry_timeout);
         assert!(imds_client
             .fetch_imds(schema_version, target)
             .await
@@ -597,6 +636,7 @@ mod test {
         let schema_version = "latest";
         let target = "meta-data/instance-type";
         let response_code = 408;
+        let retry_timeout = Duration::from_secs(2);
         server.expect(
             Expectation::matching(request::method_path("PUT", "/latest/api/token"))
                 .times(1)
@@ -611,12 +651,15 @@ mod test {
                 "GET",
                 format!("/{}/{}", schema_version, target),
             ))
-            .times(3)
+            .times(2..)
             .respond_with(
                 status_code(response_code).append_header("X-aws-ec2-metadata-token", token),
             ),
         );
-        let mut imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
+        let mut imds_client = ImdsClient::new_impl(base_uri)
+            .await
+            .unwrap()
+            .with_timeout(retry_timeout);
         assert!(imds_client
             .fetch_imds(schema_version, target)
             .await
@@ -627,14 +670,17 @@ mod test {
     async fn fetch_token_timeout() {
         let server = Server::run();
         let base_uri = format!("http://{}", server.addr());
+        let retry_timeout = Duration::from_secs(2);
         let response_code = 408;
         server.expect(
             Expectation::matching(request::method_path("PUT", "/latest/api/token"))
-                .times(3)
+                .times(2..)
                 .respond_with(status_code(response_code)),
         );
         let client = Client::new();
-        assert!(fetch_token(&client, &base_uri).await.is_err());
+        assert!(fetch_token(&client, &base_uri, &retry_timeout)
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -43,20 +43,19 @@ pub struct ImdsClient {
     client: Client,
     imds_base_uri: String,
     retry_timeout: Duration,
-    session_token: RwLock<String>,
+    session_token: RwLock<Option<String>>,
 }
 
 impl ImdsClient {
-    pub async fn new() -> Result<Self> {
-        Self::new_impl(BASE_URI.to_string()).await
+    pub fn new() -> Result<Self> {
+        Self::new_impl(BASE_URI.to_string())
     }
 
-    async fn new_impl(imds_base_uri: String) -> Result<Self> {
+    fn new_impl(imds_base_uri: String) -> Result<Self> {
         let client = Client::new();
         // Retry token timeout tied to wicked.service ifup timeout
         let retry_timeout = Duration::from_secs(300);
-        let session_token =
-            RwLock::new(fetch_token(&client, &imds_base_uri, &retry_timeout).await?);
+        let session_token = RwLock::new(None);
         Ok(Self {
             client,
             imds_base_uri,
@@ -242,11 +241,12 @@ impl ImdsClient {
         timeout(
             self.retry_timeout,
             Retry::spawn(retry_strategy(), || async {
-                let session_token = {
-                    self.session_token
-                        .read()
-                        .map_err(|_| error::Error::FailedReadToken {})?
-                        .clone()
+                let session_token = match self.read_token().await? {
+                    Some(session_token) => session_token,
+                    None => {
+                        self.write_token().await?;
+                        error::EmptyToken.fail()?
+                    }
                 };
                 let response = self
                     .client
@@ -285,7 +285,7 @@ impl ImdsClient {
                     // IMDS returns 401 if the session token is expired or invalid
                     StatusCode::UNAUTHORIZED => {
                         warn!("Session token is invalid or expired");
-                        self.refresh_token().await?;
+                        self.write_token().await?;
                         error::UnauthorizedTokenRefreshed.fail()
                     }
 
@@ -319,14 +319,28 @@ impl ImdsClient {
         .context(error::TimeoutFetchIMDS)?
     }
 
-    /// Fetches a new session token and adds it to the current ImdsClient.
-    async fn refresh_token(&self) -> Result<()> {
+    /// Fetches a new session token and writes it to the current ImdsClient.
+    async fn write_token(&self) -> Result<()> {
         *self
             .session_token
             .write()
             .map_err(|_| error::Error::FailedWriteToken {})? =
             fetch_token(&self.client, &self.imds_base_uri, &self.retry_timeout).await?;
         Ok(())
+    }
+
+    /// Helper to read session token within the ImdsClient
+    async fn read_token(&self) -> Result<Option<String>> {
+        let session_token = match self
+            .session_token
+            .read()
+            .map_err(|_| error::Error::FailedReadToken {})?
+            .clone()
+        {
+            Some(session_token) => Ok(Some(session_token)),
+            None => Ok(None),
+        };
+        session_token
     }
 }
 
@@ -373,7 +387,7 @@ async fn fetch_token(
     client: &Client,
     imds_base_uri: &str,
     retry_timeout: &Duration,
-) -> Result<String> {
+) -> Result<Option<String>> {
     let uri = format!("{}/{}", imds_base_uri, SESSION_TARGET);
     timeout(
         *retry_timeout,
@@ -390,11 +404,13 @@ async fn fetch_token(
 
             let code = response.status();
             ensure!(code == StatusCode::OK, error::FailedFetchToken);
-            return response.text().await.context(error::ResponseBody {
+
+            let response_body = response.text().await.context(error::ResponseBody {
                 method: "PUT",
                 uri: &uri,
                 code,
-            });
+            })?;
+            Ok(Some(response_body))
         }),
     )
     .await
@@ -422,6 +438,9 @@ mod error {
         // snafu doesn't yet support the lifetimes used by std::sync::PoisonError
         #[snafu(display("Response '{}' from '{}': {}", get_status_code(source), uri, source))]
         BadResponse { uri: String, source: reqwest::Error },
+
+        #[snafu(display("Fetched IMDSv2 session token"))]
+        EmptyToken,
 
         #[snafu(display("IMDS fetch failed after {} attempts", attempt))]
         FailedFetchIMDS { attempt: u8 },
@@ -499,25 +518,6 @@ mod test {
     use httptest::{matchers::*, responders::*, Expectation, Server};
 
     #[tokio::test]
-    async fn new_imds_client() {
-        let server = Server::run();
-        let base_uri = format!("http://{}", server.addr());
-        let token = "some+token";
-        server.expect(
-            Expectation::matching(request::method_path("PUT", "/latest/api/token"))
-                .times(1)
-                .respond_with(
-                    status_code(200)
-                        .append_header("X-aws-ec2-metadata-token-ttl-seconds", "60")
-                        .body(token),
-                ),
-        );
-        let imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
-        let imds_token = { imds_client.session_token.read().unwrap().clone() };
-        assert_eq!(imds_token, token);
-    }
-
-    #[tokio::test]
     async fn fetch_imds() {
         let server = Server::run();
         let base_uri = format!("http://{}", server.addr());
@@ -547,11 +547,13 @@ mod test {
                     .body(response_body),
             ),
         );
-        let mut imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
+        let mut imds_client = ImdsClient::new_impl(base_uri).unwrap();
         let imds_data = imds_client
             .fetch_imds(schema_version, target)
             .await
             .unwrap();
+        let imds_token = imds_client.read_token().await.unwrap().unwrap();
+        assert_eq!(imds_token, token);
         assert_eq!(imds_data, Some(response_body.as_bytes().to_vec()));
     }
 
@@ -582,7 +584,7 @@ mod test {
                 status_code(response_code).append_header("X-aws-ec2-metadata-token", token),
             ),
         );
-        let mut imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
+        let mut imds_client = ImdsClient::new_impl(base_uri).unwrap();
         let imds_data = imds_client
             .fetch_imds(schema_version, target)
             .await
@@ -619,7 +621,6 @@ mod test {
             ),
         );
         let mut imds_client = ImdsClient::new_impl(base_uri)
-            .await
             .unwrap()
             .with_timeout(retry_timeout);
         assert!(imds_client
@@ -657,7 +658,6 @@ mod test {
             ),
         );
         let mut imds_client = ImdsClient::new_impl(base_uri)
-            .await
             .unwrap()
             .with_timeout(retry_timeout);
         assert!(imds_client
@@ -712,7 +712,7 @@ mod test {
                     .body(response_body),
             ),
         );
-        let mut imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
+        let mut imds_client = ImdsClient::new_impl(base_uri).unwrap();
         let imds_data = imds_client.fetch_string(end_target).await.unwrap();
         assert_eq!(imds_data, Some(response_body.to_string()));
     }
@@ -746,7 +746,7 @@ mod test {
                     .body(response_body),
             ),
         );
-        let mut imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
+        let mut imds_client = ImdsClient::new_impl(base_uri).unwrap();
         let imds_data = imds_client.fetch_bytes(end_target).await.unwrap();
         assert_eq!(imds_data, Some(response_body.as_bytes().to_vec()));
     }
@@ -779,7 +779,7 @@ mod test {
                     .body(response_body),
             ),
         );
-        let mut imds_client = ImdsClient::new_impl(base_uri).await.unwrap();
+        let mut imds_client = ImdsClient::new_impl(base_uri).unwrap();
         let imds_data = imds_client.fetch_userdata().await.unwrap();
         assert_eq!(imds_data, Some(response_body.as_bytes().to_vec()));
     }


### PR DESCRIPTION
**Description of changes:**

To mitigate things like closed connections, IMDSv2 token and data
fetches will continue to retry until success or until the timeout has
been reached.

The default timeout is 300s to match the ifup timeout in wicked, but can
be set manually with `.with_timeout` when building your own ImdsClient.

A wait_for_imds function was also added if you simply want to verify
IMDS is available before proceeding.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
